### PR TITLE
Add authors to galaxy.yml.

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,4 +1,12 @@
-authors: []
+authors:
+  - chouseknecht (https://github.com/chouseknecht)
+  - geerlingguy (https://www.jeffgeerling.com/)
+  - maxamillion (https://github.com/maxamillion)
+  - jmontleon (https://github.com/jmontleon)
+  - fabianvf (https://github.com/fabianvf)
+  - willthames (https://github.com/willthames)
+  - mmazur (https://github.com/mmazur)
+  - jamescassell (https://github.com/jamescassell)
 dependencies: {}
 description: Kubernetes Collection for Ansible.
 documentation: ''


### PR DESCRIPTION
Since the git history of the ansible modules repository and ansible/ansible have diverged, it is hard to get an accurate picture of all those who have contributed and will continue contributing to the Kubernetes Collection.

I would like to get a somewhat accurate picture of those who have been and are still interested in maintaining Kubernetes content for OpenShift, so this PR is a stab at trying to get the authors field in galaxy.yml to be accurate.

Please make sure the URL listed by your username is accurate for what you'd like to display. Note that the authors information is not (to my knowledge) displayed in Galaxy's UI at this point.