### PR TITLE
k8s_log no longer attempts to parse log as JSON

### DIFF
--- a/molecule/default/tasks/log.yml
+++ b/molecule/default/tasks/log.yml
@@ -79,6 +79,43 @@
           - "'hello world' in pod_log.log"
           - item == 'hello world' or item == ''
       with_items: '{{ pod_log.log_lines }}'
+
+    - name: Create a job that calculates pi
+      k8s:
+        state: present
+        wait: yes
+        wait_timeout: 120
+        wait_condition:
+          type: Complete
+          status: 'True'
+        definition:
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+            name: pi
+            namespace: k8s-log
+          spec:
+            template:
+              spec:
+                containers:
+                - name: pi
+                  image: perl
+                  command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(20)"]
+                restartPolicy: Never
+            backoffLimit: 4
+
+    - name: retrieve logs from the job
+      k8s_log:
+        api_version: batch/v1
+        kind: Job
+        namespace: k8s-log
+        name: pi
+      register: job_logs
+
+    - name: verify the log was successfully retrieved
+      assert:
+        that: job_logs.log_lines[0] == "3.1415926535897932385"
+
   always:
     - name: ensure that namespace is removed
       k8s:

--- a/molecule/default/tasks/log.yml
+++ b/molecule/default/tasks/log.yml
@@ -98,9 +98,9 @@
             template:
               spec:
                 containers:
-                - name: pi
-                  image: perl
-                  command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(20)"]
+                  - name: pi
+                    image: perl
+                    command: ["perl", "-Mbignum=bpi", "-wle", "print bpi(20)"]
                 restartPolicy: Never
             backoffLimit: 4
 

--- a/molecule/default/tasks/log.yml
+++ b/molecule/default/tasks/log.yml
@@ -92,15 +92,15 @@
           apiVersion: batch/v1
           kind: Job
           metadata:
-            name: pi
+            name: int-log
             namespace: k8s-log
           spec:
             template:
               spec:
                 containers:
-                  - name: pi
-                    image: perl
-                    command: ["perl", "-Mbignum=bpi", "-wle", "print bpi(20)"]
+                  - name: busybox
+                    image: busybox
+                    command: ["echo", "7"]
                 restartPolicy: Never
             backoffLimit: 4
 
@@ -109,12 +109,12 @@
         api_version: batch/v1
         kind: Job
         namespace: k8s-log
-        name: pi
+        name: int-log
       register: job_logs
 
     - name: verify the log was successfully retrieved
       assert:
-        that: job_logs.log_lines[0] == "3.1415926535897932385"
+        that: job_logs.log_lines[0] == "7"
 
   always:
     - name: ensure that namespace is removed

--- a/molecule/default/tasks/log.yml
+++ b/molecule/default/tasks/log.yml
@@ -80,7 +80,7 @@
           - item == 'hello world' or item == ''
       with_items: '{{ pod_log.log_lines }}'
 
-    - name: Create a job that calculates pi
+    - name: Create a job that calculates 7
       k8s:
         state: present
         wait: yes

--- a/plugins/modules/k8s_log.py
+++ b/plugins/modules/k8s_log.py
@@ -6,6 +6,8 @@
 
 from __future__ import absolute_import, division, print_function
 
+from ansible.module_utils.six import PY2
+
 __metaclass__ = type
 
 
@@ -182,11 +184,12 @@ class KubernetesLogModule(KubernetesAnsibleModule):
         if self.params.get('container'):
             kwargs['query_params'] = dict(container=self.params['container'])
 
-        log = resource.log.get(
+        log = serialize_log(resource.log.get(
             name=name,
             namespace=self.params.get('namespace'),
+            serialize=False,
             **kwargs
-        )
+        ))
 
         self.exit_json(changed=False, log=log, log_lines=log.split('\n'))
 
@@ -226,6 +229,12 @@ class KubernetesLogModule(KubernetesAnsibleModule):
                     self.fail(msg='The k8s_log module does not support the {0} matchExpression operator'.format(operator.lower()))
 
         return selectors
+
+
+def serialize_log(response):
+    if PY2:
+        return response.data
+    return response.data.decode('utf8')
 
 
 def main():

--- a/plugins/modules/k8s_log.py
+++ b/plugins/modules/k8s_log.py
@@ -6,8 +6,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-from ansible.module_utils.six import PY2
-
 __metaclass__ = type
 
 
@@ -129,6 +127,9 @@ log_lines:
 
 
 import copy
+
+from ansible.module_utils.six import PY2
+
 from ansible_collections.community.kubernetes.plugins.module_utils.common import KubernetesAnsibleModule
 from ansible_collections.community.kubernetes.plugins.module_utils.common import AUTH_ARG_SPEC
 


### PR DESCRIPTION
##### SUMMARY
Fixes #68

Rather than relying on the default serialization logic (which attempts to parse a log as JSON and then load it into a wrapper class), we now simply return the raw log data as expected. The previous behavior worked in many cases because the log was serialized into a JSON string, but in the case of #68 the log was loaded as a JSON float, which made the error handling fail to fallback to returning the raw data.


<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
k8s_log